### PR TITLE
Capslock abuse detection

### DIFF
--- a/src/events/msg_capslock.js
+++ b/src/events/msg_capslock.js
@@ -1,0 +1,18 @@
+export const hasTextCapslockAbuse = (str) => {
+    const words = str.match(/[A-Z]+/gi)
+	if (!words) return false;
+
+	const upperLetters = str.match(/[A-Z]/g) || []
+	const lowerLetters = str.match(/[a-z]/g) || []
+	
+	const upper = upperLetters.length
+	const lower = lowerLetters.length
+
+	const upperWords =  words.filter(word => word.length > 1 && word.length / 2 < (word.match(/[A-Z]/g) || []).length)
+	const lowerWords =  words.filter(word => word.length > 1 && word.length / 2 < (word.match(/[a-z]/g) || []).length)
+
+	const upperWordsCount = upperWords.length
+	const lowerWordsCount = lowerWords.length
+	
+	return upperWordsCount > 0 && upperWordsCount > lowerWordsCount && upper > lower
+}

--- a/src/eventsdiscord/messageCreate.js
+++ b/src/eventsdiscord/messageCreate.js
@@ -12,6 +12,7 @@ module.exports = async (Redshift,message) => {
     db.reload()
     
     if (regex.test(message.content)) {
+      message.delete()
       try {
         const advs = (await db.getData(`/${message.author.id}`)) + 1
 
@@ -54,6 +55,7 @@ module.exports = async (Redshift,message) => {
         }
 
         if (hasTextCapslockAbuse(message.content)) {
+          message.delete()
           if (!capslockAlerts[message.author.id]) {
             const rocket31 = message.guild.emojis.cache.get('974544899586285579')
 

--- a/src/eventsdiscord/messageCreate.js
+++ b/src/eventsdiscord/messageCreate.js
@@ -55,7 +55,6 @@ module.exports = async (Redshift,message) => {
         }
 
         if (hasTextCapslockAbuse(message.content)) {
-          message.delete()
           if (!capslockAlerts[message.author.id]) {
             const rocket31 = message.guild.emojis.cache.get('974544899586285579')
 
@@ -72,7 +71,7 @@ module.exports = async (Redshift,message) => {
             await message.react('🇵')
             await message.react('🇸')
           } else {
-            
+            message.delete()
             if (Date.now() - capslockAlerts[message.author.id].last_message_tick < 30 * 60 * 1000) {
               capslockAlerts[message.author.id].count++;
               capslockAlerts[message.author.id].last_message_tick = Date.now();

--- a/src/eventsdiscord/messageCreate.js
+++ b/src/eventsdiscord/messageCreate.js
@@ -55,6 +55,7 @@ module.exports = async (Redshift,message) => {
         }
 
         if (hasTextCapslockAbuse(message.content)) {
+          message.delete()
           if (!capslockAlerts[message.author.id]) {
             const rocket31 = message.guild.emojis.cache.get('974544899586285579')
 
@@ -71,7 +72,7 @@ module.exports = async (Redshift,message) => {
             await message.react('🇵')
             await message.react('🇸')
           } else {
-            message.delete()
+            
             if (Date.now() - capslockAlerts[message.author.id].last_message_tick < 30 * 60 * 1000) {
               capslockAlerts[message.author.id].count++;
               capslockAlerts[message.author.id].last_message_tick = Date.now();

--- a/src/eventsdiscord/messageCreate.js
+++ b/src/eventsdiscord/messageCreate.js
@@ -1,46 +1,44 @@
 import settings from "../configs/settings.json"
 import { JsonDB } from 'node-json-db'
 import { Config } from 'node-json-db/dist/lib/JsonDBConfig'
+
+import { addMemberAdv } from '../utils/addAdv'
+import { hasTextCapslockAbuse } from "../events/msg_capslock"
+const capslockAlerts = {}
+
 module.exports = async (Redshift,message) => {
     const regex = new RegExp(`(\\b|\\d)(${settings.ForbiddenWords.join('|')})(\\b|\\d)`, 'i');
+    const db = new JsonDB(new Config("ADVS", true, false, '/'));
+    db.reload()
+    
     if (regex.test(message.content)) {
-        message.delete();
-        var db = new JsonDB(new Config("ADVS", true, false, '/'));
-        db.reload()
-        try {
-            var data = db.getData(`/${message.author.id}`)
-            db.push(`/${message.author.id}`, data+1)
-            var data = db.getData(`/${message.author.id}`)
-            if(data >= settings.MAX_ADV_TOKICK) {    
-                let guild = Redshift.guilds.cache.get(settings.GROUP_ID);
-                let member = guild.members.cache.get(message.author.id);
-                member.kick() .then(() => {
-                    message.channel.send(`**Taxado!** ${message.author} não seguiu as regras e acaba de ser kickado com **${data}** advertencias :wave:`)
-                    db.delete(`/${message.author.id}`)
-                })
-                .catch(err => {
-                    var data = db.getData(`/${message.author.id}`)
-                    db.push(`/${message.author.id}`, data)
-                    return message.channel.send(`Ocorreu um problema ao tentar kickar ${message.author}, talvez eu não tenho permissões suficientes para kickar esse usuário!`)
-                });       
-            }
-            else {
-                message.channel.send(`${message.author} Não fale isso! uma **bad-word** foi detectada, você agora tem **${data}** advertencias de ${settings.MAX_ADV_TOKICK}.`).then((m) => {
-                    setTimeout(() => {
-                        m.delete()
-                    }, 7500)
-                });
-            }
-        } catch(error) {
-            db.push(`/${message.author.id}`,1);
-            var data = db.getData(`/${message.author.id}`)
-            
-            message.channel.send(`${message.author} Não fale isso! uma **bad-word** foi detectada, você agora tem **${data}** advertencias de ${settings.MAX_ADV_TOKICK}.`).then((m) => {
-                setTimeout(() => {
-                    m.delete()
-                }, 7500)
-            });
+      try {
+        const advs = (await db.getData(`/${message.author.id}`)) + 1
+
+        if (advs >= settings.MAX_ADV_TOKICK) {
+          addMemberAdv(Redshift, message)
+          .then(() => {
+            message.channel.send(`**Taxado!** ${message.author} não seguiu as regras e acaba de ser kickado com **${advs}** advertências :wave:`)
+          })
+          .catch((err) => {
+            message.channel.send(`Ocorreu um problema ao tentar kickar ${message.author}, talvez eu não tenha permissões suficientes para kickar este usuário!`)
+          })
+        } else {
+          await addMemberAdv(Redshift, message)
+          message.channel.send(`${message.author} Não fale isso! uma **bad-word** foi detectada, você agora tem **${advs}** advertências. (${advs}/${settings.MAX_ADV_TOKICK})`).then((m) => {
+            setTimeout(() => {
+                m.delete()
+            }, 7500)
+          });
         }
+      } catch(err) {
+        await addMemberAdv(Redshift, message)
+        message.channel.send(`${message.author} Não fale isso! uma **bad-word** foi detectada, você agora tem **1** advertência. (1/${settings.MAX_ADV_TOKICK})`).then((m) => {
+            setTimeout(() => {
+                m.delete()
+            }, 7500)
+        });
+      }
     }
 
     let score;
@@ -53,6 +51,79 @@ module.exports = async (Redshift,message) => {
    
         if (!score) {
           score = { id: `${message.guild.id}-${message.author.id}`, user: message.author.id, score: 0 }
+        }
+
+        if (hasTextCapslockAbuse(message.content)) {
+          if (!capslockAlerts[message.author.id]) {
+            const rocket31 = message.guild.emojis.cache.get('974544899586285579')
+
+            capslockAlerts[message.author.id] = {
+              count: 1,
+              last_message_tick: Date.now()
+            };
+
+            if (rocket31) {
+              await message.react(rocket31)
+            }
+            await message.react('🇨')
+            await message.react('🇦')
+            await message.react('🇵')
+            await message.react('🇸')
+          } else {
+            
+            if (Date.now() - capslockAlerts[message.author.id].last_message_tick < 30 * 60 * 1000) {
+              capslockAlerts[message.author.id].count++;
+              capslockAlerts[message.author.id].last_message_tick = Date.now();
+
+              switch (capslockAlerts[message.author.id].count) {
+                case 2:
+                  message.channel.send(`${message.author} cuidado com o abuso de capslock!`);
+                  break;
+              
+                case 3:
+                  message.channel.send(`${message.author} não abuse do capslock! Caso continue, você será punido!`);
+                  break;
+
+                case 4:
+                  capslockAlerts[message.author.id] = undefined
+
+                  try {
+                    const advs = (await db.getData(`/${message.author.id}`)) + 1
+
+                    if (advs >= settings.MAX_ADV_TOKICK) {
+                      addMemberAdv(Redshift, message)
+                      .then(() => {
+                        message.channel.send(`**Taxado!** ${message.author} não seguiu as regras e acaba de ser kickado com **${advs}** advertências :wave:`)
+                      })
+                      .catch((err) => {
+                        message.channel.send(`Ocorreu um problema ao tentar kickar ${message.author}, talvez eu não tenha permissões suficientes para kickar este usuário!`)
+                      })
+                    } else {
+                      await addMemberAdv(Redshift, message)
+                      message.channel.send(`${message.author} você está recebendo uma advertência por abuso de capslock! Você agora tem **${advs}** advertências. (${advs}/${settings.MAX_ADV_TOKICK})`).then((m) => {
+                        setTimeout(() => {
+                            m.delete()
+                        }, 7500)
+                      });
+                    }
+                  } catch(err) {
+                    await addMemberAdv(Redshift, message)
+                    message.channel.send(`${message.author} você está recebendo uma advertência por abuso de capslock! Você agora tem 1 advertência. (1/${settings.MAX_ADV_TOKICK})`).then((m) => {
+                      setTimeout(() => {
+                          m.delete()
+                      }, 7500)
+                    });
+                  }
+                  break;
+
+                default:
+                  break;
+              }
+            } else {
+              capslockAlerts[message.author.id].count = 1;
+              capslockAlerts[message.author.id].last_message_tick = Date.now();
+            }
+          }
         }
   
         score.score = score.score + 10;

--- a/src/eventsdiscord/messageCreate.js
+++ b/src/eventsdiscord/messageCreate.js
@@ -78,11 +78,19 @@ module.exports = async (Redshift,message) => {
 
               switch (capslockAlerts[message.author.id].count) {
                 case 2:
-                  message.channel.send(`${message.author} cuidado com o abuso de capslock!`);
+                  message.channel.send(`${message.author} cuidado com o abuso de capslock!`).then((m) => {
+                    setTimeout(() => {
+                      m.delete()
+                    }, 7500)
+                  });
                   break;
               
                 case 3:
-                  message.channel.send(`${message.author} não abuse do capslock! Caso continue, você será punido!`);
+                  message.channel.send(`${message.author} não abuse do capslock! Caso continue, você será punido!`).then((m) => {
+                    setTimeout(() => {
+                      m.delete()
+                    }, 7500)
+                  });
                   break;
 
                 case 4:
@@ -94,10 +102,18 @@ module.exports = async (Redshift,message) => {
                     if (advs >= settings.MAX_ADV_TOKICK) {
                       addMemberAdv(Redshift, message)
                       .then(() => {
-                        message.channel.send(`**Taxado!** ${message.author} não seguiu as regras e acaba de ser kickado com **${advs}** advertências :wave:`)
+                        message.channel.send(`**Taxado!** ${message.author} não seguiu as regras e acaba de ser kickado com **${advs}** advertências :wave:`).then((m) => {
+                          setTimeout(() => {
+                            m.delete()
+                          }, 7500)
+                        });
                       })
                       .catch((err) => {
-                        message.channel.send(`Ocorreu um problema ao tentar kickar ${message.author}, talvez eu não tenha permissões suficientes para kickar este usuário!`)
+                        message.channel.send(`Ocorreu um problema ao tentar kickar ${message.author}, talvez eu não tenha permissões suficientes para kickar este usuário!`).then((m) => {
+                          setTimeout(() => {
+                            m.delete()
+                          }, 7500)
+                        });
                       })
                     } else {
                       await addMemberAdv(Redshift, message)

--- a/src/utils/addAdv.js
+++ b/src/utils/addAdv.js
@@ -1,0 +1,38 @@
+import settings from "../configs/settings.json"
+import { Client, Message } from 'discord.js';
+import { JsonDB } from 'node-json-db'
+import { Config } from 'node-json-db/dist/lib/JsonDBConfig'
+
+/**
+ * 
+ * @param {Client} Redshift 
+ * @param {Message} message 
+ */
+export const addMemberAdv = async (Redshift, message) => {
+    message.delete();
+    const db = new JsonDB(new Config("ADVS", true, false, '/'));
+    db.reload()
+    try {
+        let data = await db.getData(`/${message.author.id}`)
+        data++;
+        await db.push(`/${message.author.id}`, data)
+        if(data >= settings.MAX_ADV_TOKICK) {
+            return new Promise((resolve, reject) => {
+                let guild = Redshift.guilds.cache.get(settings.GROUP_ID);
+                let member = guild.members.cache.get(message.author.id);
+                member.kick() .then(() => {
+                    db.delete(`/${message.author.id}`)
+                    resolve()
+                })
+                .catch(async err => {
+                    const data = await db.getData(`/${message.author.id}`)
+                    db.push(`/${message.author.id}`, data)
+                    reject(err)
+                    return
+                });
+            })
+        }
+    } catch(error) {
+        db.push(`/${message.author.id}`,1);
+    }
+}

--- a/src/utils/addAdv.js
+++ b/src/utils/addAdv.js
@@ -9,7 +9,6 @@ import { Config } from 'node-json-db/dist/lib/JsonDBConfig'
  * @param {Message} message 
  */
 export const addMemberAdv = async (Redshift, message) => {
-    message.delete();
     const db = new JsonDB(new Config("ADVS", true, false, '/'));
     db.reload()
     try {


### PR DESCRIPTION
## Detectar e filtrar o abuso de capslock em mensagens enviadas nos canais de texto.

### Alertas de abuso:
Antes do membro receber uma advertência do Bot pelo abuso do capslock, o mesmo receberá **três alertas** sobre este abuso. No 4° alerta, o membro receberá a advertência.

- No **primeiro alerta** que o membro receber, a mensagem em que foi detectado o abuso será reagida pelo Bot indicando que aquela mensagem contém abuso de capslock.
- No **segundo alerta**, o Bot deleta a mensagem contendo o abuso e então envia uma mensagem no canal mencionando o membro que abusou do capslock, avisando-o para não abusar do capslock.
- No **terceiro (e último) alerta**, o Bot também apaga a mensagem do membro e lança um último aviso informando que da próxima vez o membro será advertido.
- No **último alerta**, o Bot apaga a mensagem e então dá uma advertência para o membro que abusou do capslock.

### Reset de alertas:
Os alertas de abuso se mantém por 30 minutos de desde o último abuso cometido. Se alcançar o limite dentro desse tempo, o membro é advertido e a quantidade de alertas registrados para este membro é redefinida.