### PR TITLE
Aprimoramento de detecção de capslock

### DIFF
--- a/src/events/msg_capslock.js
+++ b/src/events/msg_capslock.js
@@ -1,15 +1,15 @@
 export const hasTextCapslockAbuse = async (str) => {
-    const words = str.match(/[A-Z]+/gi)
+    const words = str.replace(/<a?:(\w+):\d+>/g, '').match(/[A-Z]+/gi)
 	if (!words) return false;
 
-	const upperLetters = str.match(/[A-Z]/g) || []
-	const lowerLetters = str.match(/[a-z]/g) || []
+	const upperLetters = str.replace(/<a?:(\w+):\d+>/g, '').match(/[A-Z]/g) || []
+	const lowerLetters = str.replace(/<a?:(\w+):\d+>/g, '').match(/[a-z]/g) || []
 	
 	const upper = upperLetters.length
 	const lower = lowerLetters.length
 
-	const upperWords =  words.filter(word => word.length > 1 && word.length / 2 < (word.match(/[A-Z]/g) || []).length)
-	const lowerWords =  words.filter(word => word.length > 1 && word.length / 2 < (word.match(/[a-z]/g) || []).length)
+	const upperWords =  words.filter(word => word.length > 1 && word.length / 2 < (word.replace(/<a?:(\w+):\d+>/g, '').match(/[A-Z]/g) || []).length)
+	const lowerWords =  words.filter(word => word.length > 1 && word.length / 2 < (word.replace(/<a?:(\w+):\d+>/g, '').match(/[a-z]/g) || []).length)
 	
 	const upperWordsCount = upperWords.length
 	const lowerWordsCount = lowerWords.length


### PR DESCRIPTION
### O Bot vai não vai mais contar os **emojis** com nomes (em sua grande parte) com letras maiúsculas como abuso de capslock.

Foi utilizado o RegEx `/<a?:(\w+):\d+>/g` com **[String.prototype.replace](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/String/replace)** para desconsiderar os emojis nas mensagens enviadas e atualizadas nos canais de texto.